### PR TITLE
Add a basic command line interface.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ format:
 	--ignore-init-module-imports --recursive pybert/ tests/; isort pybert/ tests/; black pybert/ tests/
 
 tests:
-	pytest -vv -n 4 tests/
+	pytest -vv -n 4 --disable-pytest-warnings tests/
 
 clean:
 	rm -rf .pytest_cache .tox htmlcov *.egg-info .coverage

--- a/Makefile
+++ b/Makefile
@@ -5,17 +5,20 @@ all: tests tests-ami format lint
 lint:
 	pylint pybert/ tests/; mypy -p pybert --ignore-missing-imports
 
+lint:
+	pylint pybert/ tests/
+
 format:
 	autoflake --in-place --remove-all-unused-imports --expand-star-imports \
 	--ignore-init-module-imports --recursive pybert/ tests/; isort pybert/ tests/; black pybert/ tests/
 
 tests:
-	pytest -vv -n 4 tests/ PyAMI/tests/
+	pytest -vv -n 4 tests/
 
 clean:
 	rm -rf .pytest_cache .tox htmlcov *.egg-info .coverage
 
-# Packing Conda commands ----------------------------------------------------------
+# Conda Packaging Commands ----------------------------------------------------------
 
 conda-build: tests
 	conda build conda.recipe/pybert
@@ -54,4 +57,4 @@ pybert_dev: pybert_bld
 	conda install -n pybert64 --use-local --only-deps pybert
 	conda develop -n pybert64 .
 
-# Packing Conda commands ----------------------------------------------------------
+# End Conda Packaging Commands ----------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,6 @@ all: tests tests-ami format lint
 lint:
 	pylint pybert/ tests/; mypy -p pybert --ignore-missing-imports
 
-lint:
-	pylint pybert/ tests/
-
 format:
 	autoflake --in-place --remove-all-unused-imports --expand-star-imports \
 	--ignore-init-module-imports --recursive pybert/ tests/; isort pybert/ tests/; black pybert/ tests/

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -41,4 +41,4 @@ will be run with `make tests`.
 
 The easiest way to install and test the `pybert` command is to run `pip install -e .` which will update the script link without having to rebuild and reinstall the conda package.  This
 works only because the `install_requires` field is commented out otherwise pip would try and
-fail into install the traits infrastructure.  Alternatively, the normal way of calling the package still works: `python -m pybert`.
+fail to install the traits infrastructure.  This does not change the behavior of `python -m pybert`.

--- a/pybert/__main__.py
+++ b/pybert/__main__.py
@@ -3,6 +3,7 @@ from pybert.logger import setup_logging
 from pybert.pybert import PyBERT
 from pybert.view import traits_view
 
+
 def main():
     setup_logging()
     app = PyBERT()

--- a/pybert/cdr.py
+++ b/pybert/cdr.py
@@ -11,7 +11,7 @@ integration into the larger *PyBERT* framework.
 
 Copyright (c) 2019 by David Banas; All rights reserved World wide.
 """
-from typing import Sequence, Tuple, List
+from typing import List, Sequence, Tuple
 
 from numpy import array, mean, sign, where
 

--- a/pybert/cli.py
+++ b/pybert/cli.py
@@ -1,0 +1,51 @@
+"""Command Line Interface for pybert."""
+import sys
+
+import click
+
+from pybert.logger import setup_logging
+from pybert.pybert import PyBERT
+from pybert.view import traits_view
+
+
+@click.group(invoke_without_command=True, context_settings=dict(help_option_names=["-h", "--help"]))
+@click.pass_context
+@click.version_option()
+@click.option("--config", "-c", type=click.Path(exists=True), help="Settings to run pybert with.")
+@click.option("--results", "-r", type=click.Path(exists=True), help="Recall previous results when opening pybert.")
+def cli(ctx, config, results):
+    """Command line interface for pybert."""
+    setup_logging()
+    if ctx.invoked_subcommand is None:
+        app = PyBERT(run_simulation=False, gui=True)
+
+        if config:
+            app.load_configuration(config)
+
+        # Either load old results or run the simulation to fill the plots.
+        if results:
+            app.load_results(results)
+        else:
+            app.run_simulation(inital_run=True)
+
+        # Create the GUI.
+        app.configure_traits(view=traits_view)
+
+
+@cli.command(context_settings=dict(help_option_names=["-h", "--help"]))
+@click.argument("config", type=click.Path(exists=True))
+def simulate(config):
+    """Load the configuration, simulate it and save the results.
+
+    The results will be saved into a file with the same location as the config but with the
+    .pybert_data extension.
+    """
+
+    app = PyBERT(run_simulation=False, gui=False)
+    app.load_configuration(config)
+    app.run_simulation(inital_run=True)
+    app.save_results(config.with_suffix(".pybert_data"))
+
+
+if __name__ == "__main__":
+    sys.exit(cli())  # pragma: no cover

--- a/pybert/cli.py
+++ b/pybert/cli.py
@@ -1,7 +1,6 @@
 """Command Line Interface for pybert."""
-from pathlib import Path
-import logging
 import sys
+from pathlib import Path
 
 import click
 
@@ -35,6 +34,7 @@ def cli(ctx, config, results, verbose):
         # Create the GUI.
         pybert.configure_traits(view=traits_view)
 
+
 @cli.command(context_settings=dict(help_option_names=["-h", "--help"]))
 @click.argument("config", type=click.Path(exists=True))
 @click.option("--verbose", "-v", is_flag=True, help="Enable debug printing.")
@@ -48,6 +48,7 @@ def simulate(config, verbose):
     pybert.load_configuration(config)
     my_run_simulation(pybert, initial_run=True, update_plots=False)
     pybert.save_results(Path(config).with_suffix(".pybert_data"))
+
 
 if __name__ == "__main__":
     sys.exit(cli())  # pragma: no cover

--- a/pybert/cli.py
+++ b/pybert/cli.py
@@ -1,8 +1,11 @@
 """Command Line Interface for pybert."""
+from pathlib import Path
+import logging
 import sys
 
 import click
 
+from pybert.control import my_run_simulation
 from pybert.logger import setup_logging
 from pybert.pybert import PyBERT
 from pybert.view import traits_view
@@ -11,41 +14,40 @@ from pybert.view import traits_view
 @click.group(invoke_without_command=True, context_settings=dict(help_option_names=["-h", "--help"]))
 @click.pass_context
 @click.version_option()
-@click.option("--config", "-c", type=click.Path(exists=True), help="Settings to run pybert with.")
-@click.option("--results", "-r", type=click.Path(exists=True), help="Recall previous results when opening pybert.")
-def cli(ctx, config, results):
-    """Command line interface for pybert."""
-    setup_logging()
+@click.option("--config", "-c", type=click.Path(exists=True), help="Load with a existing configuration.")
+@click.option("--results", "-r", type=click.Path(exists=True), help="Load with results from a prior run.")
+@click.option("--verbose", "-v", is_flag=True, help="Enable debug printing.")
+def cli(ctx, config, results, verbose):
+    """Command line interface for pybert.
+
+    Provides a simple way to start pybert with non-default settings.
+    Sub-commands add additional features such as simulation in a headless fashion.
+    """
     if ctx.invoked_subcommand is None:
-        app = PyBERT(run_simulation=False, gui=True)
+        setup_logging(verbose)
+        pybert = PyBERT()
 
         if config:
-            app.load_configuration(config)
-
-        # Either load old results or run the simulation to fill the plots.
+            pybert.load_configuration(config)
         if results:
-            app.load_results(results)
-        else:
-            app.run_simulation(inital_run=True)
+            pybert.load_results(results)
 
         # Create the GUI.
-        app.configure_traits(view=traits_view)
-
+        pybert.configure_traits(view=traits_view)
 
 @cli.command(context_settings=dict(help_option_names=["-h", "--help"]))
 @click.argument("config", type=click.Path(exists=True))
-def simulate(config):
-    """Load the configuration, simulate it and save the results.
+@click.option("--verbose", "-v", is_flag=True, help="Enable debug printing.")
+def simulate(config, verbose):
+    """Run a simulation using an existing configuration.
 
-    The results will be saved into a file with the same location as the config but with the
-    .pybert_data extension.
+    The results will be saved in a file with the same name but with the results extension.
     """
-
-    app = PyBERT(run_simulation=False, gui=False)
-    app.load_configuration(config)
-    app.run_simulation(inital_run=True)
-    app.save_results(config.with_suffix(".pybert_data"))
-
+    setup_logging(verbose)
+    pybert = PyBERT(run_simulation=False, gui=False)
+    pybert.load_configuration(config)
+    my_run_simulation(pybert, initial_run=True, update_plots=False)
+    pybert.save_results(Path(config).with_suffix(".pybert_data"))
 
 if __name__ == "__main__":
     sys.exit(cli())  # pragma: no cover

--- a/pybert/configuration.py
+++ b/pybert/configuration.py
@@ -12,8 +12,6 @@ configuration could be saved and later restored.
 
 Copyright (c) 2017 by David Banas; All rights reserved World wide.
 """
-
-
 class PyBertCfg:
     """
     PyBERT simulation configuration data encapsulation class.
@@ -23,11 +21,14 @@ class PyBertCfg:
     clicks the "Save Config." button.
     """
 
-    def __init__(self, the_PyBERT):
+    def __init__(self, the_PyBERT, timestamp, version):
         """
         Copy just that subset of the supplied PyBERT instance's
         __dict__, which should be saved during pickling.
         """
+        # Generic Information
+        self.date_created = timestamp
+        self.version = version
 
         # Simulation Control
         self.bit_rate = the_PyBERT.bit_rate

--- a/pybert/control.py
+++ b/pybert/control.py
@@ -8,15 +8,15 @@ Original date:   August 24, 2014 (Copied from pybert.py, as part of a major code
 Copyright (c) 2014 David Banas; all rights reserved World wide.
 """
 from time import perf_counter
+
 clock = perf_counter
 
+import numpy as np
 from chaco.api import Plot
 from chaco.tools.api import PanTool, ZoomTool
-import numpy as np
 from numpy import (
     arange,
     array,
-    concatenate,
     convolve,
     correlate,
     cumsum,
@@ -26,7 +26,6 @@ from numpy import (
     mean,
     ones,
     pad,
-    real,
     repeat,
     resize,
     std,
@@ -38,7 +37,6 @@ from numpy.fft import fft, irfft
 from numpy.random import normal
 from scipy.signal import iirfilter, lfilter
 from scipy.signal.windows import hann
-from pyibisami.ami_model import AMIModel, AMIModelInitializer
 
 from pybert.dfe import DFE
 from pybert.utility import (
@@ -50,6 +48,7 @@ from pybert.utility import (
     safe_log10,
     trim_impulse,
 )
+from pyibisami.ami_model import AMIModel, AMIModelInitializer
 
 DEBUG = False
 MIN_BATHTUB_VAL = 1.0e-18

--- a/pybert/logger.py
+++ b/pybert/logger.py
@@ -1,11 +1,12 @@
 """The logging and debug functionality of pybert."""
+import json
 import logging
+import time
 from logging import Logger
 from pathlib import Path
-import json
-import time
 
 from traitsui.message import message
+
 
 def setup_logging(verbose=False) -> Logger:
     """Create a console and file handler with the level set to Debug."""

--- a/pybert/logger.py
+++ b/pybert/logger.py
@@ -7,7 +7,7 @@ import time
 
 from traitsui.message import message
 
-def setup_logging() -> Logger:
+def setup_logging(verbose=False) -> Logger:
     """Create a console and file handler with the level set to Debug."""
     log = logging.getLogger()
 
@@ -16,7 +16,10 @@ def setup_logging() -> Logger:
     ch_format = logging.Formatter("%(levelname)s - %(message)s")
 
     console_handler.setFormatter(ch_format)
-    console_handler.setLevel(logging.ERROR)
+    if verbose:
+        console_handler.setLevel(logging.DEBUG)
+    else:
+        console_handler.setLevel(logging.ERROR)
 
     # Setup a File Logger
     log_file = Path.cwd().joinpath("pybert.log")
@@ -30,7 +33,11 @@ def setup_logging() -> Logger:
 
     log.addHandler(console_handler)
     log.addHandler(file_handler)
-    log.setLevel(logging.INFO)
+    if verbose:
+        log.setLevel(logging.DEBUG)
+    else:
+        log.setLevel(logging.INFO)
+
     log.info(f"Log file created at: {log_file}")
 
     return log

--- a/pybert/logger.py
+++ b/pybert/logger.py
@@ -54,7 +54,7 @@ class ConsoleTextLogHandler(logging.Handler):
         self.application.console_log += f"{msg}\n"
 
         show_user_alert = False
-        if isinstance(record.args, dict):
+        if isinstance(record.args, dict): # if no kwargs are passed, record.args is an empty tuple.
             show_user_alert = record.args.get("alert", False)
         if self.application.has_gui and show_user_alert:
             message(msg, "PyBERT Alert")

--- a/pybert/plot.py
+++ b/pybert/plot.py
@@ -10,8 +10,6 @@ Copyright (c) 2015 David Banas; all rights reserved World wide.
 from chaco.api import ColorMapper, GridPlotContainer, Plot
 from chaco.tools.api import PanTool, ZoomTool
 
-from numpy import linspace
-
 from pybert.control import update_eyes
 
 PLOT_SPACING = 20

--- a/pybert/pybert.py
+++ b/pybert/pybert.py
@@ -15,30 +15,20 @@ can be used to explore the concepts of serial communication link design.
 Copyright (c) 2014 by David Banas; All rights reserved World wide.
 """
 import logging
-from traits.etsconfig.api import ETSConfig
-# ETSConfig.toolkit = 'qt.celiagg'  # Yields unacceptably small font sizes in plot axis labels.
-# ETSConfig.toolkit = 'qt.qpainter'  # Was causing crash on Mac.
-
-from datetime import datetime
+import pickle
 import platform
 import time
 from os.path import dirname, join
 from pathlib import Path
-from threading import Event, Thread
-from time import sleep
 
-from math  import isnan
-from cmath import rect, phase
-
-from chaco.api import ArrayPlotData, GridPlotContainer
 import numpy as np
-from numpy import array, convolve, cos, diff, exp, ones, pad, pi, real, resize, sinc, where, zeros
+import skrf as rf
+import yaml
+from chaco.api import ArrayPlotData, GridPlotContainer
+from numpy import array, convolve, cos, exp, ones, pad, pi, resize, sinc, where, zeros
 from numpy.fft import fft, irfft
 from numpy.random import randint
-from os.path import dirname, join
-from scipy.optimize import minimize, minimize_scalar
 from traits.api import (
-    HTML,
     Array,
     Bool,
     Button,
@@ -53,21 +43,12 @@ from traits.api import (
     Range,
     String,
     cached_property,
-    Trait,
 )
 from traits.etsconfig.api import ETSConfig
-import yaml
-import pickle
+# ETSConfig.toolkit = 'qt.celiagg'  # Yields unacceptably small font sizes in plot axis labels.
+# ETSConfig.toolkit = 'qt.qpainter'  # Was causing crash on Mac.
 
-import skrf as rf
 
-from pyibisami import __version__ as PyAMI_VERSION
-from pyibisami.ami_parse import AMIParamConfigurator
-from pyibisami.ami_model import AMIModel
-from pyibisami.ibis_file import IBISModel
-
-from pybert import __version__ as VERSION
-from pybert import __date__ as DATE
 from pybert import __authors__ as AUTHORS
 from pybert import __copy__ as COPY
 from pybert import __date__ as DATE
@@ -78,25 +59,25 @@ from pybert.help import help_str
 from pybert.logger import ConsoleTextLogHandler
 from pybert.plot import make_plots
 from pybert.results import PyBertData
-from pybert.threads import CoOptThread, RxOptThread, TxOptThread, TxTapTuner
+from pybert.threads import CoOptThread, RxOptThread, TxOptThread
 from pybert.utility import (
-    calc_G,
     calc_gamma,
     import_channel,
+    interp_s2p,
+    interp_time,
     lfsr_bits,
     make_ctle,
     pulse_center,
     safe_log10,
-    trim_impulse,
-    submodules,
     sdd_21,
-    H_2_s2p,
-    interp_time,
-    cap_mag,
-    interp_s2p,
-    renorm_s2p,
+    trim_impulse,
 )
-from pybert.view import traits_view
+from pyibisami import __version__ as PyAMI_VERSION
+from pyibisami.ami_model import AMIModel
+from pyibisami.ami_parse import AMIParamConfigurator
+from pyibisami.ibis_file import IBISModel
+
+
 
 gDebugStatus = False
 gDebugOptimize = False
@@ -154,203 +135,6 @@ gRelLockTol = 0.1  # relative lock tolerance of CDR.
 gLockSustain = 500
 # - Analysis
 gThresh = 6  # threshold for identifying periodic jitter spectral elements (sigma)
-
-
-class StoppableThread(Thread):
-    """
-    Thread class with a stop() method.
-
-    The thread itself has to check regularly for the stopped() condition.
-
-    All PyBERT thread classes are subclasses of this class.
-    """
-
-    def __init__(self):
-        super(StoppableThread, self).__init__()
-        self._stop_event = Event()
-
-    def stop(self):
-        """Called by thread invoker, when thread should be stopped prematurely."""
-        self._stop_event.set()
-
-    def stopped(self):
-        """Should be called by thread (i.e. - subclass) periodically and, if this function
-        returns True, thread should clean itself up and quit ASAP.
-        """
-        return self._stop_event.is_set()
-
-
-class TxOptThread(StoppableThread):
-    """Used to run Tx tap weight optimization in its own thread,
-    in order to preserve GUI responsiveness.
-    """
-
-    def run(self):
-        """Run the Tx equalization optimization thread."""
-
-        pybert = self.pybert
-
-        if self.update_status:
-            pybert.status = "Optimizing Tx..."
-
-        max_iter = pybert.max_iter
-
-        old_taps = []
-        min_vals = []
-        max_vals = []
-        for tuner in pybert.tx_tap_tuners:
-            if tuner.enabled:
-                old_taps.append(tuner.value)
-                min_vals.append(tuner.min_val)
-                max_vals.append(tuner.max_val)
-
-        cons = {"type": "ineq", "fun": lambda x: 0.7 - sum(abs(x))}
-
-        bounds = list(zip(min_vals, max_vals))
-
-        try:
-            if gDebugOptimize:
-                res = minimize(
-                    self.do_opt_tx,
-                    old_taps,
-                    bounds=bounds,
-                    constraints=cons,
-                    options={"disp": True, "maxiter": max_iter},
-                )
-            else:
-                res = minimize(
-                    self.do_opt_tx,
-                    old_taps,
-                    bounds=bounds,
-                    constraints=cons,
-                    options={"disp": False, "maxiter": max_iter},
-                )
-
-            if self.update_status:
-                if res["success"]:
-                    pybert.status = "Optimization succeeded."
-                else:
-                    pybert.status = "Optimization failed: {}".format(res["message"])
-
-        except Exception as err:
-            pybert.status = err
-
-    def do_opt_tx(self, taps):
-        """Run the Tx Optimization."""
-        sleep(0.001)  # Give the GUI a chance to acknowledge user clicking the Abort button.
-
-        if self.stopped():
-            raise RuntimeError("Optimization aborted.")
-
-        pybert = self.pybert
-        tuners = pybert.tx_tap_tuners
-        taps = list(taps)
-        for tuner in tuners:
-            if tuner.enabled:
-                tuner.value = taps.pop(0)
-        return pybert.cost
-
-
-class RxOptThread(StoppableThread):
-    """Used to run Rx tap weight optimization in its own thread,
-    in order to preserve GUI responsiveness.
-    """
-
-    def run(self):
-        """Run the Rx equalization optimization thread."""
-
-        pybert = self.pybert
-
-        pybert.status = "Optimizing Rx..."
-        max_iter = pybert.max_iter
-
-        try:
-            if gDebugOptimize:
-                res = minimize_scalar(
-                    self.do_opt_rx,
-                    bounds=(0, gMaxCTLEPeak),
-                    method="Bounded",
-                    options={"disp": True, "maxiter": max_iter},
-                )
-            else:
-                res = minimize_scalar(
-                    self.do_opt_rx,
-                    bounds=(0, gMaxCTLEPeak),
-                    method="Bounded",
-                    options={"disp": False, "maxiter": max_iter},
-                )
-
-            if res["success"]:
-                pybert.status = "Optimization succeeded."
-            else:
-                pybert.status = "Optimization failed: {}".format(res["message"])
-
-        except Exception as err:
-            pybert.status = err
-
-    def do_opt_rx(self, peak_mag):
-        """Run the Rx Optimization."""
-        sleep(0.001)  # Give the GUI a chance to acknowledge user clicking the Abort button.
-
-        if self.stopped():
-            raise RuntimeError("Optimization aborted.")
-
-        pybert = self.pybert
-        pybert.peak_mag_tune = peak_mag
-        return pybert.cost
-
-
-class CoOptThread(StoppableThread):
-    """Used to run co-optimization in its own thread, in order to preserve GUI responsiveness."""
-
-    def run(self):
-        """Run the Tx/Rx equalization co-optimization thread."""
-
-        pybert = self.pybert
-
-        pybert.status = "Co-optimizing..."
-        max_iter = pybert.max_iter
-
-        try:
-            if gDebugOptimize:
-                res = minimize_scalar(
-                    self.do_coopt,
-                    bounds=(0, gMaxCTLEPeak),
-                    method="Bounded",
-                    options={"disp": True, "maxiter": max_iter},
-                )
-            else:
-                res = minimize_scalar(
-                    self.do_coopt,
-                    bounds=(0, gMaxCTLEPeak),
-                    method="Bounded",
-                    options={"disp": False, "maxiter": max_iter},
-                )
-
-            if res["success"]:
-                pybert.status = "Optimization succeeded."
-            else:
-                pybert.status = "Optimization failed: {}".format(res["message"])
-
-        except Exception as err:
-            pybert.status = err
-
-    def do_coopt(self, peak_mag):
-        """Run the Tx and Rx Co-Optimization."""
-        sleep(0.001)  # Give the GUI a chance to acknowledge user clicking the Abort button.
-
-        if self.stopped():
-            raise RuntimeError("Optimization aborted.")
-
-        pybert = self.pybert
-        pybert.peak_mag_tune = peak_mag
-        if any([pybert.tx_tap_tuners[i].enabled for i in range(len(pybert.tx_tap_tuners))]):
-            while pybert.tx_opt_thread and pybert.tx_opt_thread.isAlive():
-                sleep(0.001)
-            pybert._do_opt_tx(update_status=False)
-            while pybert.tx_opt_thread and pybert.tx_opt_thread.isAlive():
-                sleep(0.001)
-        return pybert.cost
 
 
 class TxTapTuner(HasTraits):

--- a/pybert/pybert.py
+++ b/pybert/pybert.py
@@ -1701,6 +1701,7 @@ class PyBERT(HasTraits):
         Support both file formats either yaml or pickle.
         """
         try:
+            filepath = Path(filepath)
             if filepath.suffix == ".yaml":
                 with open(filepath, "rt") as the_file:
                     user_config = yaml.load(the_file, Loader=yaml.Loader)
@@ -1740,6 +1741,7 @@ class PyBERT(HasTraits):
         """
         current_config = PyBertCfg(self, time.asctime(), VERSION)
         try:
+            filepath = Path(filepath)
             if filepath.suffix == ".yaml":
                 with open(filepath, "wt") as the_file:
                     yaml.dump(current_config, the_file)
@@ -1759,6 +1761,7 @@ class PyBERT(HasTraits):
     def load_results(self, filepath:Path):
         """Load results from a file into pybert."""
         try:
+            filepath = Path(filepath)
             with open(filepath, "rb") as the_file:
                 user_results = pickle.load(the_file)
             if not isinstance(user_results, PyBertData):

--- a/pybert/results.py
+++ b/pybert/results.py
@@ -48,7 +48,7 @@ class PyBertData:
         "ctle_out_H",
         "dfe_out_H",
         "tx_out",
-        "rx_in",
+        # "rx_in", # TODO: There is no plot for this which crashes loading results.
     ]
 
     def __init__(self, the_PyBERT):

--- a/pybert/solver.py
+++ b/pybert/solver.py
@@ -13,7 +13,6 @@ Each solver must define how the standard interface is implemented.
 Copyright (c) 2019 by David Banas; all rights reserved World wide.
 """
 from abc import ABC, abstractmethod
-from typing import List, Tuple, Dict
 from enum import Enum
 
 ChType = Enum("ChType", "microstrip_se microstrip_diff stripline_se stripline_diff")
@@ -50,4 +49,3 @@ class Solver(ABC):
             Zc: Frequency dependent complex impedance.
             freqs: List of frequencies at which ``gamma`` and ``Zc`` were sampled.
         """
-        pass

--- a/pybert/solvers/simbeor/__init__.py
+++ b/pybert/solvers/simbeor/__init__.py
@@ -18,7 +18,9 @@ Copyright (c) 2019 by David Banas; all rights reserved World wide.
 import logging
 import os
 import os.path as osp
+
 import numpy as np
+
 import pybert.solver as slvr
 
 sdkdir = os.environ.get("SIMBEOR_SDK")

--- a/pybert/threads.py
+++ b/pybert/threads.py
@@ -2,7 +2,6 @@ from threading import Event, Thread
 from time import sleep
 
 from scipy.optimize import minimize, minimize_scalar
-from traits.api import Bool, Float, HasTraits, Int, String
 
 from pybert.control import my_run_sweeps
 
@@ -211,28 +210,3 @@ class CoOptThread(StoppableThread):
             while pybert.tx_opt_thread and pybert.tx_opt_thread.isAlive():
                 sleep(0.001)
         return pybert.cost
-
-
-class TxTapTuner(HasTraits):
-    """Object used to populate the rows of the Tx FFE tap tuning table."""
-
-    name = String("(noname)")
-    enabled = Bool(False)
-    min_val = Float(0.0)
-    max_val = Float(0.0)
-    value = Float(0.0)
-    steps = Int(0)  # Non-zero means we want to sweep it.
-
-    def __init__(self, name="(noname)", enabled=False, min_val=0.0, max_val=0.0, value=0.0, steps=0):
-        """Allows user to define properties, at instantiation."""
-
-        # Super-class initialization is ABSOLUTELY NECESSARY, in order
-        # to get all the Traits/UI machinery setup correctly.
-        super(TxTapTuner, self).__init__()
-
-        self.name = name
-        self.enabled = enabled
-        self.min_val = min_val
-        self.max_val = max_val
-        self.value = value
-        self.steps = steps

--- a/pybert/threads.py
+++ b/pybert/threads.py
@@ -1,0 +1,238 @@
+from threading import Event, Thread
+from time import sleep
+
+from scipy.optimize import minimize, minimize_scalar
+from traits.api import Bool, Float, HasTraits, Int, String
+
+from pybert.control import my_run_sweeps
+
+gDebugOptimize = False
+gMaxCTLEPeak = 20.0  # max. allowed CTLE peaking (dB) (when optimizing, only)
+
+class RunSimThread(Thread):
+    """Used to run the simulation in its own thread, in order to preserve GUI responsiveness."""
+
+    def run(self):
+        """Run the simulation(s)."""
+        my_run_sweeps(self.the_pybert)
+
+class StoppableThread(Thread):
+    """
+    Thread class with a stop() method.
+
+    The thread itself has to check regularly for the stopped() condition.
+
+    All PyBERT thread classes are subclasses of this class.
+    """
+
+    def __init__(self):
+        super(StoppableThread, self).__init__()
+        self._stop_event = Event()
+
+    def stop(self):
+        """Called by thread invoker, when thread should be stopped prematurely."""
+        self._stop_event.set()
+
+    def stopped(self):
+        """Should be called by thread (i.e. - subclass) periodically and, if this function
+        returns True, thread should clean itself up and quit ASAP.
+        """
+        return self._stop_event.is_set()
+
+
+class TxOptThread(StoppableThread):
+    """Used to run Tx tap weight optimization in its own thread,
+    in order to preserve GUI responsiveness.
+    """
+
+    def run(self):
+        """Run the Tx equalization optimization thread."""
+
+        pybert = self.pybert
+
+        if self.update_status:
+            pybert.status = "Optimizing Tx..."
+
+        max_iter = pybert.max_iter
+
+        old_taps = []
+        min_vals = []
+        max_vals = []
+        for tuner in pybert.tx_tap_tuners:
+            if tuner.enabled:
+                old_taps.append(tuner.value)
+                min_vals.append(tuner.min_val)
+                max_vals.append(tuner.max_val)
+
+        cons = {"type": "ineq", "fun": lambda x: 0.7 - sum(abs(x))}
+
+        bounds = list(zip(min_vals, max_vals))
+
+        try:
+            if gDebugOptimize:
+                res = minimize(
+                    self.do_opt_tx,
+                    old_taps,
+                    bounds=bounds,
+                    constraints=cons,
+                    options={"disp": True, "maxiter": max_iter},
+                )
+            else:
+                res = minimize(
+                    self.do_opt_tx,
+                    old_taps,
+                    bounds=bounds,
+                    constraints=cons,
+                    options={"disp": False, "maxiter": max_iter},
+                )
+
+            if self.update_status:
+                if res["success"]:
+                    pybert.status = "Optimization succeeded."
+                else:
+                    pybert.status = "Optimization failed: {}".format(res["message"])
+
+        except Exception as err:
+            pybert.status = err
+
+    def do_opt_tx(self, taps):
+        """Run the Tx Optimization."""
+        sleep(0.001)  # Give the GUI a chance to acknowledge user clicking the Abort button.
+
+        if self.stopped():
+            raise RuntimeError("Optimization aborted.")
+
+        pybert = self.pybert
+        tuners = pybert.tx_tap_tuners
+        taps = list(taps)
+        for tuner in tuners:
+            if tuner.enabled:
+                tuner.value = taps.pop(0)
+        return pybert.cost
+
+
+class RxOptThread(StoppableThread):
+    """Used to run Rx tap weight optimization in its own thread,
+    in order to preserve GUI responsiveness.
+    """
+
+    def run(self):
+        """Run the Rx equalization optimization thread."""
+
+        pybert = self.pybert
+
+        pybert.status = "Optimizing Rx..."
+        max_iter = pybert.max_iter
+
+        try:
+            if gDebugOptimize:
+                res = minimize_scalar(
+                    self.do_opt_rx,
+                    bounds=(0, gMaxCTLEPeak),
+                    method="Bounded",
+                    options={"disp": True, "maxiter": max_iter},
+                )
+            else:
+                res = minimize_scalar(
+                    self.do_opt_rx,
+                    bounds=(0, gMaxCTLEPeak),
+                    method="Bounded",
+                    options={"disp": False, "maxiter": max_iter},
+                )
+
+            if res["success"]:
+                pybert.status = "Optimization succeeded."
+            else:
+                pybert.status = "Optimization failed: {}".format(res["message"])
+
+        except Exception as err:
+            pybert.status = err
+
+    def do_opt_rx(self, peak_mag):
+        """Run the Rx Optimization."""
+        sleep(0.001)  # Give the GUI a chance to acknowledge user clicking the Abort button.
+
+        if self.stopped():
+            raise RuntimeError("Optimization aborted.")
+
+        pybert = self.pybert
+        pybert.peak_mag_tune = peak_mag
+        return pybert.cost
+
+
+class CoOptThread(StoppableThread):
+    """Used to run co-optimization in its own thread, in order to preserve GUI responsiveness."""
+
+    def run(self):
+        """Run the Tx/Rx equalization co-optimization thread."""
+
+        pybert = self.pybert
+
+        pybert.status = "Co-optimizing..."
+        max_iter = pybert.max_iter
+
+        try:
+            if gDebugOptimize:
+                res = minimize_scalar(
+                    self.do_coopt,
+                    bounds=(0, gMaxCTLEPeak),
+                    method="Bounded",
+                    options={"disp": True, "maxiter": max_iter},
+                )
+            else:
+                res = minimize_scalar(
+                    self.do_coopt,
+                    bounds=(0, gMaxCTLEPeak),
+                    method="Bounded",
+                    options={"disp": False, "maxiter": max_iter},
+                )
+
+            if res["success"]:
+                pybert.status = "Optimization succeeded."
+            else:
+                pybert.status = "Optimization failed: {}".format(res["message"])
+
+        except Exception as err:
+            pybert.status = err
+
+    def do_coopt(self, peak_mag):
+        """Run the Tx and Rx Co-Optimization."""
+        sleep(0.001)  # Give the GUI a chance to acknowledge user clicking the Abort button.
+
+        if self.stopped():
+            raise RuntimeError("Optimization aborted.")
+
+        pybert = self.pybert
+        pybert.peak_mag_tune = peak_mag
+        if any([pybert.tx_tap_tuners[i].enabled for i in range(len(pybert.tx_tap_tuners))]):
+            while pybert.tx_opt_thread and pybert.tx_opt_thread.isAlive():
+                sleep(0.001)
+            pybert._do_opt_tx(update_status=False)
+            while pybert.tx_opt_thread and pybert.tx_opt_thread.isAlive():
+                sleep(0.001)
+        return pybert.cost
+
+
+class TxTapTuner(HasTraits):
+    """Object used to populate the rows of the Tx FFE tap tuning table."""
+
+    name = String("(noname)")
+    enabled = Bool(False)
+    min_val = Float(0.0)
+    max_val = Float(0.0)
+    value = Float(0.0)
+    steps = Int(0)  # Non-zero means we want to sweep it.
+
+    def __init__(self, name="(noname)", enabled=False, min_val=0.0, max_val=0.0, value=0.0, steps=0):
+        """Allows user to define properties, at instantiation."""
+
+        # Super-class initialization is ABSOLUTELY NECESSARY, in order
+        # to get all the Traits/UI machinery setup correctly.
+        super(TxTapTuner, self).__init__()
+
+        self.name = name
+        self.enabled = enabled
+        self.min_val = min_val
+        self.max_val = max_val
+        self.value = value
+        self.steps = steps

--- a/pybert/utility.py
+++ b/pybert/utility.py
@@ -7,14 +7,16 @@ Original date:   September 27, 2014 (Copied from control.py.)
 
 Copyright (c) 2014 David Banas; all rights reserved World wide.
 """
+import importlib
 import logging
 import os.path
-import re
-from functools import reduce
 import pkgutil
-import importlib
+import re
+from cmath import phase, rect
+from functools import reduce
 
 import numpy as np
+import skrf as rf
 from numpy import (
     array,
     concatenate,
@@ -39,11 +41,9 @@ from numpy import (
     zeros,
 )
 from numpy.fft import fft, ifft
-from scipy.signal import freqs, get_window, invres
-from scipy.stats import norm
 from scipy.linalg import inv
-import skrf as rf
-from cmath import rect, phase
+from scipy.signal import freqs, invres
+from scipy.stats import norm
 
 debug = False
 gDebugOptimize = False

--- a/pybert/view.py
+++ b/pybert/view.py
@@ -716,7 +716,7 @@ traits_view = View(
                 label="About",
             ),
             Group(Item("instructions", style="readonly", show_label=False), label="Guide"),
-            Group(Item("console_log",  style="custom",   show_label=False), label="Console", id="console"),
+            Group(Item("console_log",  style="readonly",   show_label=False), label="Console", id="console"),
             layout='tabbed',
             label='Help',
             id='help'

--- a/pybert/view.py
+++ b/pybert/view.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from enable.component_editor import ComponentEditor
 from pyface.api import OK, FileDialog
 from pyface.image_resource import ImageResource
-from traits.api import Instance, HasTraits
+from traits.api import Instance
 from traitsui.api import (
     Action,
     CheckListEditor,
@@ -26,13 +26,10 @@ from traitsui.api import (
     TextEditor,
     VGroup,
     View,
-    Label,
-    EnumEditor,
     spring,
 )
 
 from pybert.threads import RunSimThread
-
 
 
 class MyHandler(Handler):

--- a/pybert/view.py
+++ b/pybert/view.py
@@ -7,9 +7,7 @@ Original date:   August 24, 2014 (Copied from pybert.py, as part of a major code
 
 Copyright (c) 2014 David Banas; all rights reserved World wide.
 """
-import yaml
-import pickle
-from threading import Thread
+from pathlib import Path
 
 from enable.component_editor import ComponentEditor
 from pyface.api import OK, FileDialog
@@ -32,18 +30,9 @@ from traitsui.api import (
     EnumEditor,
     spring,
 )
-from pybert.configuration import PyBertCfg
-from pybert.control import my_run_sweeps
-from pybert.results import PyBertData
 
-USE_YAML = True  # `true`: yaml; `false`: pickle
+from pybert.threads import RunSimThread
 
-class RunSimThread(Thread):
-    """Used to run the simulation in its own thread, in order to preserve GUI responsiveness."""
-
-    def run(self):
-        """Run the simulation(s)."""
-        my_run_sweeps(self.the_pybert)
 
 
 class MyHandler(Handler):
@@ -51,7 +40,7 @@ class MyHandler(Handler):
 
     run_sim_thread = Instance(RunSimThread)
 
-    def do_run_simulation(self, info):
+    def run_simulation_clicked(self, info):
         """Spawn a simulation thread and run with the current settings."""
         the_pybert = info.object
         if self.run_sim_thread and self.run_sim_thread.isAlive():
@@ -61,168 +50,55 @@ class MyHandler(Handler):
             self.run_sim_thread.the_pybert = the_pybert
             self.run_sim_thread.start()
 
-    def do_stop_simulation(self):
+    def stop_simulation_clicked(self):
         """Kill the simulation thread."""
         if self.run_sim_thread and self.run_sim_thread.isAlive():
             self.run_sim_thread.stop()
 
-    def do_save_cfg(self, info):
-        """Pickle out the current configuration."""
-        the_pybert = info.object
-        if USE_YAML:
-            dlg = FileDialog(action="save as", wildcard="*.yaml", default_path=the_pybert.cfg_file)
-        else:
-            dlg = FileDialog(action="save as", wildcard="*.pybert_cfg", default_path=the_pybert.cfg_file)
-        if dlg.open() == OK:
-            the_PyBertCfg = PyBertCfg(the_pybert)
-            try:
-                # Store all the instance variables from `the_PyBertCfg` into the selected file.
-                if USE_YAML:
-                    with open(dlg.path, "wt") as the_file:
-                        yaml.dump(the_PyBertCfg, the_file)
-                else:
-                    with open(dlg.path, "wb") as the_file:
-                        pickle.dump(the_PyBertCfg, the_file)
-                the_pybert.cfg_file = dlg.path  # Preserve the user-selected directory/file, for next time.
-                the_pybert.log(f"Configuration saved to {the_pybert.cfg_file}")
-            except Exception as err:
-                error_message = f"The following error occured:\n\t{err}\nThe configuration was NOT saved."
-                the_pybert.log("Exception raised by pybert.view.MyHandler.do_save_cfg().",
-                    exception=RuntimeError(error_message)
-                )
+    def save_config_clicked(self, info):
+        """Prompt the user to choose where to save the config and save it."""
+        pybert = info.object
+        dialog = FileDialog(
+            action="save as",
+            wildcard="Yaml Config (*.yaml)|*.yaml|Pickle Config (*.pybert_cfg)|*.pybert_cfg|All Files|*",
+            default_path=pybert.cfg_file
+        )
+        if dialog.open() == OK:
+            pybert.save_configuration(Path(dialog.path))
 
-    def do_load_cfg(self, info):
-        """Read in the pickled configuration."""
-        the_pybert = info.object
-        if USE_YAML:
-            dlg = FileDialog(action="open", wildcard="*.yaml", default_path=the_pybert.cfg_file)
-        else:
-            dlg = FileDialog(action="open", wildcard="*.pybert_cfg", default_path=the_pybert.cfg_file)
-        if dlg.open() == OK:
-            try:
-                if USE_YAML:
-                    with open(dlg.path, "rt") as the_file:
-                        the_PyBertCfg = yaml.load(the_file, Loader=yaml.Loader)
-                else:
-                    with open(dlg.path, "rb") as the_file:
-                        the_PyBertCfg = pickle.load(the_file)
-                if not isinstance(the_PyBertCfg, PyBertCfg):
-                    raise Exception("The data structure read in is NOT of type: PyBertCfg!")
-                for prop, value in vars(the_PyBertCfg).items():
-                    if prop == "tx_taps":
-                        for count, (enabled, val) in enumerate(value):
-                            setattr(the_pybert.tx_taps[count], "enabled", enabled)
-                            setattr(the_pybert.tx_taps[count], "value", val)
-                    elif prop == "tx_tap_tuners":
-                        for count, (enabled, val) in enumerate(value):
-                            setattr(the_pybert.tx_tap_tuners[count], "enabled", enabled)
-                            setattr(the_pybert.tx_tap_tuners[count], "value", val)
-                    else:
-                        setattr(the_pybert, prop, value)
-                the_pybert.cfg_file = dlg.path
-                the_pybert.log(f"Configuration loaded from {the_pybert.cfg_file}")
-            except Exception as err:
-                error_message = f"The following error occured:\n\t{err}\nThe configuration was NOT loaded."
-                the_pybert.log("Exception raised by pybert.view.MyHandler.do_load_cfg().",
-                    exception=RuntimeError(error_message)
-                )
+    def load_config_clicked(self, info):
+        """Prompt the user to choose where to load the config from and load it."""
+        pybert = info.object
+        dialog = FileDialog(
+            action="open",
+            wildcard="Yaml Config (*.yaml)|*.yaml|Pickle Config (*.pybert_cfg)|*.pybert_cfg|All Files|*",
+            default_path=pybert.cfg_file
+        )
+        if dialog.open() == OK:
+            pybert.load_configuration(Path(dialog.path))
 
-    def do_save_data(self, info):
-        """Pickle out all the generated data."""
-        the_pybert = info.object
-        dlg = FileDialog(action="save as", wildcard="*.pybert_data", default_path=the_pybert.data_file)
-        if dlg.open() == OK:
-            try:
-                plotdata = PyBertData(the_pybert)
-                with open(dlg.path, "wb") as the_file:
-                    pickle.dump(plotdata, the_file)
-                the_pybert.data_file = dlg.path
-            except Exception as err:
-                error_message = f"The following error occured:\n\t{err}\nThe data was NOT saved."
-                the_pybert.log("Exception raised by pybert.view.MyHandler.do_save_data().",
-                    exception=RuntimeError(error_message)
-                )
+    def save_data_clicked(self, info):
+        """Prompt the user to choose where to save the results and save it."""
+        pybert = info.object
+        dialog = FileDialog(action="save as", wildcard="*.pybert_data", default_path=pybert.data_file)
+        if dialog.open() == OK:
+            pybert.save_results(Path(dialog.path))
 
-    def do_load_data(self, info):
-        """Read in the pickled data.'"""
-        the_pybert = info.object
-        dlg = FileDialog(action="open", wildcard="*.pybert_data", default_path=the_pybert.data_file)
-        if dlg.open() == OK:
-            try:
-                with open(dlg.path, "rb") as the_file:
-                    the_plotdata = pickle.load(the_file)
-                if not isinstance(the_plotdata, PyBertData):
-                    raise Exception("The data structure read in is NOT of type: ArrayPlotData!")
-                for prop, value in the_plotdata.the_data.arrays.items():
-                    the_pybert.plotdata.set_data(prop + "_ref", value)
-                the_pybert.data_file = dlg.path
-
-                # Add reference plots, if necessary.
-                # - time domain
-                for (container, suffix, has_both) in [
-                    (the_pybert.plots_h.component_grid.flat, "h", False),
-                    (the_pybert.plots_s.component_grid.flat, "s", True),
-                    (the_pybert.plots_p.component_grid.flat, "p", False),
-                ]:
-                    if "Reference" not in container[0].plots:
-                        (ix, prefix) = (0, "chnl")
-                        item_name = prefix + "_" + suffix + "_ref"
-                        container[ix].plot(("t_ns_chnl", item_name), type="line", color="darkcyan", name="Inc_ref")
-                        for (ix, prefix) in [(1, "tx"), (2, "ctle"), (3, "dfe")]:
-                            item_name = prefix + "_out_" + suffix + "_ref"
-                            container[ix].plot(
-                                ("t_ns_chnl", item_name), type="line", color="darkmagenta", name="Cum_ref"
-                            )
-                        if has_both:
-                            for (ix, prefix) in [(1, "tx"), (2, "ctle"), (3, "dfe")]:
-                                item_name = prefix + "_" + suffix + "_ref"
-                                container[ix].plot(
-                                    ("t_ns_chnl", item_name), type="line", color="darkcyan", name="Inc_ref"
-                                )
-
-                # - frequency domain
-                for (container, suffix, has_both) in [(the_pybert.plots_H.component_grid.flat, "H", True)]:
-                    if "Reference" not in container[0].plots:
-                        (ix, prefix) = (0, "chnl")
-                        item_name = prefix + "_" + suffix + "_ref"
-                        container[ix].plot(
-                            ("f_GHz", item_name), type="line", color="darkcyan", name="Inc_ref", index_scale="log"
-                        )
-                        for (ix, prefix) in [(1, "tx"), (2, "ctle"), (3, "dfe")]:
-                            item_name = prefix + "_out_" + suffix + "_ref"
-                            container[ix].plot(
-                                ("f_GHz", item_name),
-                                type="line",
-                                color="darkmagenta",
-                                name="Cum_ref",
-                                index_scale="log",
-                            )
-                        if has_both:
-                            for (ix, prefix) in [(1, "tx"), (2, "ctle"), (3, "dfe")]:
-                                item_name = prefix + "_" + suffix + "_ref"
-                                container[ix].plot(
-                                    ("f_GHz", item_name),
-                                    type="line",
-                                    color="darkcyan",
-                                    name="Inc_ref",
-                                    index_scale="log",
-                                )
-
-            except Exception as err:
-                error_message = f"The following error occured while processing item: {item_name}:\n \
-\t{err}\nThe configuration was NOT saved."
-                the_pybert.log("Exception raised by pybert.view.MyHandler.do_load_data().",
-                    exception=RuntimeError(error_message)
-                )
+    def load_data_clicked(self, info):
+        """Prompt the user to choose where to load the results from and load it."""
+        pybert = info.object
+        dialog = FileDialog(action="open", wildcard="*.pybert_data", default_path=pybert.data_file)
+        if dialog.open() == OK:
+            pybert.load_results(Path(dialog.path))
 
 # These are the "globally applicable" buttons referred to in pybert.py,
 # just above the button definitions (approx. line 580).
-run_sim = Action(name="Run", action="do_run_simulation")
-stop_sim = Action(name="Stop", action="do_stop_simulation")
-save_data = Action(name="Save Results", action="do_save_data")
-load_data = Action(name="Load Results", action="do_load_data")
-save_cfg = Action(name="Save Config.", action="do_save_cfg")
-load_cfg = Action(name="Load Config.", action="do_load_cfg")
+run_sim = Action(name="Run", action="run_simulation_clicked")
+stop_sim = Action(name="Stop", action="stop_simulation_clicked")
+save_data = Action(name="Save Results", action="save_data_clicked")
+load_data = Action(name="Load Results", action="load_data_clicked")
+save_cfg = Action(name="Save Config.", action="save_config_clicked")
+load_cfg = Action(name="Load Config.", action="load_config_clicked")
 
 # Main window layout definition.
 traits_view = View(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,4 +10,4 @@ addopts = "-vv"
 
 [tool.pylint.'MESSAGES CONTROL']
 max-line-length = 119
-disable=C0301,invalid-name,wrong-import-position
+disable="C0301,invalid-name,wrong-import-position"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,8 @@ line-length = 119
 
 [tool.isort]
 profile = "black"
+known_first_party = ["pybert", "pyibisami"]
+known_third_party = ["traits", "traitsui", "chaco", "enable"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -1,10 +1,11 @@
-from click.testing import CliRunner
-import pytest
 import logging
 
+from click.testing import CliRunner
+
+from pybert import __version__
 from pybert.cli import cli
 from pybert.pybert import PyBERT
-from pybert import __version__
+
 
 def test_cli_version(tmp_path):
     """Make sure that the command line interface functions enough to print a version."""

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -1,0 +1,29 @@
+from click.testing import CliRunner
+import pytest
+import logging
+
+from pybert.cli import cli
+from pybert.pybert import PyBERT
+from pybert import __version__
+
+def test_cli_version(tmp_path):
+    """Make sure that the command line interface functions enough to print a version."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--version"])
+    assert result.exit_code == 0
+    assert __version__ in result.output
+
+def test_cli_simulate(caplog, tmp_path):
+    """Make sure that pybert can run without a gui and generate a results file output."""
+    caplog.set_level(logging.DEBUG)
+
+    app = PyBERT(run_simulation=False, gui=False)
+    config_file = tmp_path.joinpath("config.yaml")
+    app.save_configuration(config_file)
+    assert config_file.exists()
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["simulate", str(config_file)])
+    saved_results = config_file.with_suffix(".pybert_data")
+    assert result.exit_code == 0
+    assert saved_results.exists()

--- a/tests/test_loading_and_saving.py
+++ b/tests/test_loading_and_saving.py
@@ -1,0 +1,125 @@
+import logging
+import pickle
+
+import pytest
+import numpy as np
+import yaml
+
+from pybert.pybert import VERSION, PyBERT
+
+
+def test_save_config_as_yaml(tmp_path):
+    """Make sure that pybert can correctly generate a yaml file that can get reloaded."""
+    app = PyBERT(run_simulation=False, gui=False)
+    save_file = tmp_path.joinpath("config.yaml")
+    app.save_configuration(save_file)
+
+    assert save_file.exists()  # File was created.
+
+    with open(save_file, "r") as saved_config_file:
+        user_config = yaml.load(saved_config_file, Loader=yaml.Loader)
+        assert user_config.version == VERSION
+
+
+def test_save_config_as_pickle(tmp_path):
+    """Make sure that pybert can correctly generate a pickle file that can get reloaded."""
+    app = PyBERT(run_simulation=False, gui=False)
+    save_file = tmp_path.joinpath("config.pybert_cfg")
+    app.save_configuration(save_file)
+
+    assert save_file.exists()  # File was created.
+
+    with open(save_file, "rb") as saved_config_file:
+        user_config = pickle.load(saved_config_file)
+        assert user_config.version == VERSION
+
+
+def test_save_config_as_invalid(tmp_path, caplog):
+    """When given an unsupported file suffix, no file should be generated and an message logged."""
+    caplog.set_level(logging.INFO)
+
+    app = PyBERT(run_simulation=False, gui=False)
+    save_file = tmp_path.joinpath("config.json")
+    app.save_configuration(save_file)
+
+    assert not save_file.exists()  # File should not have been created.
+    assert "Pybert does not support this file type." in caplog.text
+
+
+def test_save_results_as_pickle(tmp_path):
+    """Make sure that pybert can correctly generate a waveform pickle file that can get reloaded."""
+    app = PyBERT(run_simulation=False, gui=False)
+    save_file = tmp_path.joinpath("results.pybert_data")
+    app.save_results(save_file)
+
+    assert save_file.exists()  # File was created.
+
+    with open(save_file, "rb") as saved_results_file:
+        results = pickle.load(saved_results_file)
+        assert results.the_data.arrays
+
+
+def test_load_config_from_yaml(tmp_path):
+    """Make sure that pybert can correctly load a yaml file."""
+    app = PyBERT(run_simulation=False, gui=False)
+    save_file = tmp_path.joinpath("config.yaml")
+    app.save_configuration(save_file)
+    TEST_NUMBER_OF_BITS = 1234
+
+    # Modify the saved yaml file.
+    with open(save_file, "r") as saved_config_file:
+        user_config = yaml.load(saved_config_file, Loader=yaml.Loader)
+        user_config.nbits = TEST_NUMBER_OF_BITS  # Normally, 8000
+    with open(save_file, "w") as saved_config_file:
+        yaml.dump(user_config, saved_config_file)
+
+    app.load_configuration(save_file)
+    assert app.nbits == TEST_NUMBER_OF_BITS
+
+
+def test_load_config_from_pickle(tmp_path):
+    """Make sure that pybert can correctly load a pickle file."""
+    app = PyBERT(run_simulation=False, gui=False)
+    save_file = tmp_path.joinpath("config.pybert_cfg")
+    app.save_configuration(save_file)
+    TEST_PATTERN_LENGTH = 31
+
+    # Modify the saved pickle file.
+    with open(save_file, "rb") as saved_config_file:
+        user_config = pickle.load(saved_config_file)
+        user_config.pattern_len = TEST_PATTERN_LENGTH  # Normally, 127
+    with open(save_file, "wb") as saved_config_file:
+        pickle.dump(user_config, saved_config_file)
+
+    app.load_configuration(save_file)
+    assert app.pattern_len == TEST_PATTERN_LENGTH
+
+
+def test_load_config_from_invalid(tmp_path, caplog):
+    """When given an unsupported file suffix, no file should be read and an message logged."""
+    caplog.set_level(logging.INFO)
+
+    app = PyBERT(run_simulation=False, gui=False)
+    save_file = tmp_path.joinpath("config.json")
+    app.load_configuration(save_file)
+
+    assert "Pybert does not support this file type." in caplog.text
+
+@pytest.mark.xfail
+def test_load_results_from_pickle(tmp_path, caplog):
+    """Make sure that pybert can correctly load a pickle file."""
+    caplog.set_level(logging.DEBUG)
+    app = PyBERT(run_simulation=True, gui=False)
+    save_file = tmp_path.joinpath("config.pybert_data")
+    app.save_results(save_file)
+
+    # Modify the saved pickle file.
+    with open(save_file, "rb") as saved_results_file:
+        user_results = pickle.load(saved_results_file)
+        user_results.the_data.update_data({"chnl_h": np.array([1, 2, 3, 4])})
+    with open(save_file, "wb") as saved_results_file:
+        pickle.dump(user_results, saved_results_file)
+
+    caplog.clear()
+    app.load_results(save_file)
+    assert app.plotdata.get_data("chnl_h").size == 4

--- a/tests/test_loading_and_saving.py
+++ b/tests/test_loading_and_saving.py
@@ -1,8 +1,8 @@
 import logging
 import pickle
 
-import pytest
 import numpy as np
+import pytest
 import yaml
 
 from pybert.pybert import VERSION, PyBERT


### PR DESCRIPTION
Add a good starting point to run pybert from the command line and headless.   Still need to figure out how to correctly install via the conda infrastructure but in developer mode, you can install it with `pip install -e .`.

```bash
pybert -h
Usage: pybert [OPTIONS] COMMAND [ARGS]...

  Command line interface for pybert.

  Provides a simple way to start pybert with non-default settings. Sub-
  commands add additional features such as simulation in a headless fashion.

Options:
  --version           Show the version and exit.
  -c, --config PATH   Load with a existing configuration.
  -r, --results PATH  Load with results from a prior run.
  -v, --verbose       Enable debug printing.
  -h, --help          Show this message and exit.

Commands:
  simulate  Run a simulation using an existing configuration.
```

```bash
pybert simulate -h
Usage: pybert simulate [OPTIONS] CONFIG

  Run a simulation using an existing configuration.

  The results will be saved in a file with the same name but with the results
  extension.

Options:
  -v, --verbose  Enable debug printing.
  -h, --help     Show this message and exit.
```